### PR TITLE
Remove tech tags; add dividers between experiences

### DIFF
--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -50,38 +50,6 @@
   margin-bottom: 2.5rem;
 }
 
-.techGrid {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 0.6rem;
-}
-
-.techTag {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.45rem 0.9rem;
-  background: var(--sub-white);
-  border: 1px solid rgba(67, 97, 238, 0.1);
-  border-radius: 50px;
-  font-size: 0.82rem;
-  font-weight: 500;
-  color: var(--sub-dark);
-  transition: all 0.2s ease;
-}
-
-.techTag:hover {
-  border-color: var(--sub-primary-light);
-  box-shadow: 0 2px 8px rgba(67, 97, 238, 0.08);
-  transform: translateY(-1px);
-}
-
-.techTag i {
-  color: var(--sub-primary);
-  font-size: 0.9rem;
-}
-
 .currently {
   margin-top: 2.5rem;
   margin-bottom: 1.5rem;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,16 +7,6 @@ import Footer from '@/components/Footer/Footer';
 import { getAssetPath } from '@/lib/basePath';
 import styles from './page.module.css';
 
-const techStack = [
-  { icon: 'fab fa-python', name: 'Python' },
-  { icon: 'fab fa-java', name: 'Java' },
-  { icon: 'fab fa-js-square', name: 'JavaScript' },
-  { icon: 'fab fa-react', name: 'React' },
-  { icon: 'fas fa-database', name: 'SQL' },
-  { icon: 'fab fa-git-alt', name: 'Git' },
-  { icon: 'fab fa-docker', name: 'Docker' },
-];
-
 export default function Home() {
   return (
     <div className={styles.body}>
@@ -40,16 +30,6 @@ export default function Home() {
         <p className={styles.tagline}>
           Computer Science &amp; Mathematics at Georgia Tech.
         </p>
-
-        <div className={styles.techGrid}>
-          {techStack.map((tech) => (
-            <Magnetic key={tech.name} strength={0.4}>
-              <span className={styles.techTag}>
-                <i className={tech.icon}></i> {tech.name}
-              </span>
-            </Magnetic>
-          ))}
-        </div>
 
         <div className={styles.currently}>
           <h2 className={styles.currentlyTitle}>Currently</h2>

--- a/src/app/professional/page.module.css
+++ b/src/app/professional/page.module.css
@@ -155,8 +155,16 @@
 
 .expItem {
   position: relative;
-  margin-bottom: 2rem;
+  margin-bottom: 0;
   padding-left: 1rem;
+}
+
+.expDivider {
+  border: none;
+  height: 1px;
+  background: rgba(67, 97, 238, 0.18);
+  margin: 1.5rem 1rem 1.5rem;
+  width: 50%;
 }
 
 .expItem:last-child {

--- a/src/app/professional/page.tsx
+++ b/src/app/professional/page.tsx
@@ -151,6 +151,7 @@ export default function ProfessionalPage() {
                     <p className={styles.expDesc}>{exp.description}</p>
                   </div>
                 </div>
+                {index < experiences.length - 1 && <hr className={styles.expDivider} />}
               </FadeInOnScroll>
             ))}
           </div>


### PR DESCRIPTION
Remove the tech stack chips from the home page (deleted techStack array, techGrid/techTag styles, and their Magnetic-wrapped rendering) to simplify the UI. Add a visual divider between professional experience items by introducing .expDivider CSS, rendering <hr className={styles.expDivider}/> between entries, and adjusting .expItem bottom margin for consistent spacing.